### PR TITLE
package.json: correct semvar version if we wish to include beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la-web-components",
-  "version": "0.1-beta.1",
+  "version": "1.0.0-beta",
   "description": "Laws.Africa Web Components",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",


### PR DESCRIPTION
correct semvar version
semantically 0.1-beta.1 is incorrect but 1.0.0-beta is correct