### PR TITLE
toc-item.scss: set height to .indented

### DIFF
--- a/src/components/toc-item/toc-item.scss
+++ b/src/components/toc-item/toc-item.scss
@@ -9,6 +9,7 @@ la-toc-item {
 
   .indented {
     width: 1.4em;
+    height: 1.4em;
   }
 
   .content {


### PR DESCRIPTION
enforce height on toc indent.
Should developer wish to use a bigger icon, then they can just override and adjust the styling
DEMO
https://www.loom.com/share/3ca0cb3d2f1547bb861c7078e459d131