### PR TITLE
Automatically publish to github packages when a new release is created

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Compile and push to dist branch
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build and Push
+    steps:
+      - name: git-checkout
+        uses: actions/checkout@v2
+
+      - name: Install all dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Build storybook
+        run: npm run build-storybook
+
+      - name: Push
+        uses: EndBug/add-and-commit@v7
+        with:
+          add: 'dist --force'
+          message: 'Add built artefacts'
+          push: 'origin HEAD:dist --force'
+
+      - name: Publish Storybook
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: storybook-static/
+          SINGLE_COMMIT: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,38 +1,25 @@
-name: Compile and push to dist branch
+name: Publish npm package
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [created]
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
-    name: Build and Push
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: git-checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Install all dependencies
-        run: npm install
-
-      - name: Build
-        run: npm run build
-
-      - name: Build storybook
-        run: npm run build-storybook
-
-      - name: Push
-        uses: EndBug/add-and-commit@v7
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v2
         with:
-          add: 'dist --force'
-          message: 'Add built artefacts'
-          push: 'origin HEAD:dist --force'
+          node-version: '12.x'
+          registry-url: 'https://npm.pkg.github.com'
 
-      - name: Publish Storybook
-        uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: storybook-static/
-          SINGLE_COMMIT: true
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ To run the unit tests for the components, run:
 npm test
 ```
 
-## Releasing a new version
+# Releasing a new version
 
-1. Update the version number in package.json
+1. Update the version number: `npm version --no-git-tag-version <version>`
 2. Commit and push to GitHub on the master branch
 3. GitHub will build the package into the `dist` branch
 4. Tag and release using GitHub off of the `dist` branch
+5. GitHub will release a new version of the built package to GitHub packages
 
 # Copyright and license
 


### PR DESCRIPTION
As per https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-github-packages

I added this because otherwise getting hold of the `dist` branch to have the correct `dist` folder when publishing to github is a mission.

* use `npm version` to update package.json (see https://docs.npmjs.com/cli/v7/commands/npm-version)
* when a new release is tagged and created, the workflow runs to publish it to github packages