### PR TITLE
Build to master rather than dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install all dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run build
@@ -27,7 +27,6 @@ jobs:
         with:
           add: 'dist --force'
           message: 'Add built artefacts'
-          push: 'origin HEAD:dist --force'
 
       - name: Publish Storybook
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14'
           registry-url: 'https://npm.pkg.github.com'
 
       - run: npm ci

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ npm test
 # Releasing a new version
 
 1. Update the version number: `npm version --no-git-tag-version <version>`
-2. Commit and push to GitHub on the master branch
-3. GitHub will build the package into the `dist` branch
-4. Tag and release using GitHub off of the `dist` branch
+2. Commit and push to GitHub using a Pull Request onto the master branch
+3. GitHub will build the package and update the `dist` directory
+4. [Tag and release using GitHub](https://github.com/laws-africa/la-web-components/releases/new) off of the `master` branch
 5. GitHub will release a new version of the built package to GitHub packages
 
 # Copyright and license


### PR DESCRIPTION
We've all been bitten by broken release off of master instead of dist.
So let's just build to master.