### PR TITLE
Don't use the button element in the TOC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@laws-africa/web-components",
-  "version": "0.6.2-beta",
+  "version": "0.7.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@laws-africa/web-components",
   "author": "Greg Kempe <greg@laws.africa>",
-  "version": "0.6.3-beta",
+  "version": "0.7.0-beta",
   "description": "Laws.Africa Web Components",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components/toc-item/toc-item.scss
+++ b/src/components/toc-item/toc-item.scss
@@ -43,5 +43,10 @@ la-toc-item {
     border: none;
     box-shadow: none;
     cursor: pointer;
+    display: inline-block;
+    // mimic button styles
+    font-size: smaller;
+    text-align: center;
+    padding: 1px 6px;
   }
 }

--- a/src/components/toc-item/toc-item.scss
+++ b/src/components/toc-item/toc-item.scss
@@ -39,9 +39,6 @@ la-toc-item {
   }
 
   .indented__toggle-btn {
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
     cursor: pointer;
     display: inline-block;
     // mimic button styles

--- a/src/components/toc-item/toc-item.tsx
+++ b/src/components/toc-item/toc-item.tsx
@@ -89,9 +89,9 @@ export class TocItem {
         <div class="indented">
           {isParent
             ? (
-            <button class="indented__toggle-btn" type="button" onClick={() => this.toggle()}>
+            <div class="indented__toggle-btn" onClick={() => this.toggle()}>
               {renderToggleBtnInner()}
-            </button>
+            </div>
               )
             : null}
         </div>

--- a/src/components/toc-item/toc-item.tsx
+++ b/src/components/toc-item/toc-item.tsx
@@ -89,7 +89,7 @@ export class TocItem {
         <div class="indented">
           {isParent
             ? (
-            <div class="indented__toggle-btn" onClick={() => this.toggle()}>
+            <div class="indented__toggle-btn" role="button" onClick={() => this.toggle()}>
               {renderToggleBtnInner()}
             </div>
               )


### PR DESCRIPTION
Some sites have styled the button element and it completely messes with the layout of the TOC. Instead, mimic basic button styles applied by the browser and use a div.

broken example:

![image](https://user-images.githubusercontent.com/4178542/155692323-12a7f611-69c0-45e2-8b99-29eb932ceaed.png)

